### PR TITLE
Spring 2025 updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ FROM ${BASE_IMAGE} AS base
 ARG USE_GIT_BRANCH=version-0.24.3
 
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
 
 # libraries needed for building
 RUN apt-get -y install meson \
@@ -71,8 +70,7 @@ RUN mkdir /source
 WORKDIR /source
 RUN git clone https://github.com/GioF71/MPD.git --branch ${USE_GIT_BRANCH}
 WORKDIR /source/MPD
-RUN meson . output/release -Ddocumentation=disabled -Dtest=false -Dsystemd=disabled -Dpcre=enabled
-RUN meson configure output/release
+RUN meson setup . output/release --buildtype=release -Db_ndebug=false
 RUN ninja -C output/release
 RUN mkdir -p /app/bin
 RUN cp /source/MPD/output/release/mpd /app/bin/mpd

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ See the following table for changes starting from 2023-07-20.
 
 Date|Major Changes
 :---|:---
+2025-05-08|Build in release mode
+2025-05-08|Avoid apt-get upgrade
+2025-05-08|Remove non-lts ubuntu base images
+2025-05-08|Sort debian versions in build.sh
 2025-04-13|Bump to mpd 0.24.3 (see issue [#58](https://github.com/GioF71/mpd-compiler-docker/issues/58))
 2025-03-27|Bump to mpd 0.24.2 (see issue [#56](https://github.com/GioF71/mpd-compiler-docker/issues/56))
 2025-03-23|Bump to mpd 0.24.1 (see issue [#54](https://github.com/GioF71/mpd-compiler-docker/issues/54))

--- a/build.sh
+++ b/build.sh
@@ -21,12 +21,9 @@ declare -A local_tag
 local_tag[sid]=local-sid
 local_tag[trixie]=local-trixie
 local_tag[bookworm]=local-bookworm
-local_tag[buster]=local-buster
 local_tag[bullseye]=local-bullseye
+local_tag[buster]=local-buster
 local_tag[noble]=local-noble
-local_tag[mantic]=local-mantic
-local_tag[lunar]=local-lunar
-local_tag[kinetic]=local-kinetic
 local_tag[jammy]=local-jammy
 local_tag[focal]=local-focal
 local_tag[bionic]=local-bionic


### PR DESCRIPTION
- Sort debian versions in build.sh
- Remove non-lts ubuntu base images
- Avoid apt-get upgrade
- Build in release mode